### PR TITLE
Check for Removed Handles in Poll Service

### DIFF
--- a/src/th_poll_service.c
+++ b/src/th_poll_service.c
@@ -215,6 +215,8 @@ th_poll_service_run(void* self, int timeout_ms)
     size_t reenqueue = 0;
     for (size_t i = 0; i < service->nfds; ++i) {
         th_poll_handle* handle = th_poll_handle_map_try_get(&service->handles, service->fds[i].fd);
+        if (!handle) // handle was removed
+            continue;
         short revents = service->fds[i].revents;
         short events = service->fds[i].events & (POLLIN | POLLOUT);
         int op_index = 0;


### PR DESCRIPTION
- Add a check to ensure that handles are not processed if they have been removed.