### PR TITLE
Fix Invalid Memory Write and Add Test for Detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ if (NOT TH_DISABLE_TESTS)
         src/th_list_test.c
         src/th_dir_mgr_test.c
         src/th_tcp_socket_test.c
+        src/th_heap_string_test.c
     )
 
     create_test_sourcelist(TH_TEST_SRC_LIST th_test.c

--- a/src/th_heap_string.c
+++ b/src/th_heap_string.c
@@ -56,7 +56,8 @@ th_heap_string_small_to_large(th_heap_string* self, size_t capacity)
 {
     TH_ASSERT(self->impl.small.small);
     th_detail_large_string large = {0};
-    large.capacity = TH_HEAP_STRING_ALIGNUP(capacity);
+    capacity = TH_HEAP_STRING_ALIGNUP(capacity);
+    large.capacity = capacity;
     large.len = self->impl.small.len;
     large.ptr = th_allocator_alloc(self->impl.small.allocator, capacity);
     if (large.ptr == NULL) {

--- a/src/th_heap_string_test.c
+++ b/src/th_heap_string_test.c
@@ -1,0 +1,54 @@
+#include "th_heap_string.h"
+#include "th_test.h"
+
+TH_TEST_BEGIN(heap_string)
+{
+    TH_TEST_CASE_BEGIN(heap_string_init)
+    {
+        th_heap_string str;
+        th_heap_string_init(&str, th_default_allocator_get());
+        TH_EXPECT(th_heap_string_len(&str) == 0);
+        TH_EXPECT(th_heap_string_data(&str) != NULL);
+        th_heap_string_deinit(&str);
+    }
+    TH_TEST_CASE_END
+    TH_TEST_CASE_BEGIN(heap_string_set)
+    {
+        th_heap_string str;
+        th_heap_string_init(&str, th_default_allocator_get());
+        th_string s = TH_STRING("hello");
+        TH_EXPECT(th_heap_string_set(&str, s) == TH_ERR_OK);
+        TH_EXPECT(th_heap_string_len(&str) == s.len);
+        TH_EXPECT(th_string_eq(th_heap_string_view(&str), s));
+        s = TH_STRING("Lorem ipsum dolor sit amet");
+        TH_EXPECT(th_heap_string_set(&str, s) == TH_ERR_OK);
+        TH_EXPECT(th_heap_string_len(&str) == s.len);
+        TH_EXPECT(th_string_eq(th_heap_string_view(&str), s));
+        s = TH_STRING("");
+        TH_EXPECT(th_heap_string_set(&str, s) == TH_ERR_OK);
+        TH_EXPECT(th_heap_string_len(&str) == s.len);
+        TH_EXPECT(th_string_eq(th_heap_string_view(&str), s));
+        s = TH_STRING("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas ullamcorper mi ut felis pulvinar tincidunt.");
+        TH_EXPECT(th_heap_string_set(&str, s) == TH_ERR_OK);
+        TH_EXPECT(th_heap_string_len(&str) == s.len);
+        TH_EXPECT(th_string_eq(th_heap_string_view(&str), s));
+        s = TH_STRING("");
+        TH_EXPECT(th_heap_string_set(&str, s) == TH_ERR_OK);
+        TH_EXPECT(th_heap_string_len(&str) == s.len);
+        TH_EXPECT(th_string_eq(th_heap_string_view(&str), s));
+        th_heap_string_deinit(&str);
+    }
+    TH_TEST_CASE_END
+    TH_TEST_CASE_BEGIN(heap_string_append)
+    {
+        th_heap_string str;
+        th_heap_string_init(&str, th_default_allocator_get());
+        for (int i = 0; i < 100; ++i) {
+            TH_EXPECT(th_heap_string_append(&str, TH_STRING("A")) == TH_ERR_OK);
+            TH_EXPECT(th_heap_string_len(&str) == (size_t)(i + 1));
+        }
+        th_heap_string_deinit(&str);
+    }
+    TH_TEST_CASE_END
+}
+TH_TEST_END


### PR DESCRIPTION
- Correct buffer allocation size in th_heap_string.
- Add heap_string_test to catch the crash that was fixed.