### PR TITLE
refactor: rename add_root functions to add_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ int main(void)
     th_server* server;
     th_server_create(&server, NULL);
     th_bind(server, "0.0.0.0", "8080", NULL);
-    th_add_root(server, "root", "/path/to/your/files");
+    th_add_dir(server, "root", "/path/to/your/files");
     th_route(server, TH_METHOD_GET, "/{path:path}", handle_path, NULL);
     th_route(server, TH_METHOD_GET, "/", handle_index, NULL);
     while (1) {

--- a/benchmark/tiny_http_static.c
+++ b/benchmark/tiny_http_static.c
@@ -30,7 +30,7 @@ int main()
         goto cleanup;
     if ((err = th_bind(server, "0.0.0.0", "8080", NULL)) != TH_ERR_OK)
         goto cleanup;
-    if ((err = th_add_root(server, "root", "testfiles")) != TH_ERR_OK)
+    if ((err = th_add_dir(server, "root", "testfiles")) != TH_ERR_OK)
         goto cleanup;
     if ((err = th_route(server, TH_METHOD_GET, "/{path:path}", handle_path, NULL)) != TH_ERR_OK)
         goto cleanup;

--- a/examples/file_server.c
+++ b/examples/file_server.c
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
     opt.key_file = key;
     if ((err = th_bind(server, "0.0.0.0", port, &opt)) != TH_ERR_OK)
         goto cleanup;
-    if ((err = th_add_root(server, "root", root)) != TH_ERR_OK)
+    if ((err = th_add_dir(server, "root", root)) != TH_ERR_OK)
         goto cleanup;
     if ((err = th_route(server, TH_METHOD_GET, "/{path:path}", handle_path, NULL)) != TH_ERR_OK)
         goto cleanup;

--- a/examples/file_upload.c
+++ b/examples/file_upload.c
@@ -43,7 +43,7 @@ int main(void)
     }
     if ((err = th_bind(server, "0.0.0.0", "8080", NULL)) != TH_ERR_OK)
         goto cleanup;
-    if ((err = th_add_root(server, "upload_dir", "./uploads")) != TH_ERR_OK)
+    if ((err = th_add_dir(server, "upload_dir", "./uploads")) != TH_ERR_OK)
         goto cleanup;
     if ((err = th_route(server, TH_METHOD_POST, "/", handler, NULL)) != TH_ERR_OK)
         goto cleanup;

--- a/include/th.h
+++ b/include/th.h
@@ -329,12 +329,12 @@ th_err th_bind(th_server* server, const char* addr, const char* port, th_bind_op
 th_err th_route(th_server* server, th_method method, const char* route, th_handler handler, void* userp);
 
 /** th_err
- * @brief Add a root directory to the server.
- * @param name Label for the root directory.
+ * @brief Add a directory to the server (for serving or storing files).
+ * @param name Label for the directory.
  * @param path File system path.
  * @return TH_ERR_OK on success, otherwise an error code.
  */
-th_err th_add_root(th_server* server, const char* name, const char* path);
+th_err th_add_dir(th_server* server, const char* name, const char* path);
 
 /** th_poll
  * @brief Poll the server for any events and pending tasks.

--- a/src/th_fcache.c
+++ b/src/th_fcache.c
@@ -117,7 +117,7 @@ th_fcache_try_get(th_fcache* cache, th_string root, th_string path)
 }
 
 TH_PRIVATE(th_err)
-th_fcache_add_root(th_fcache* cache, th_string label, th_string path)
+th_fcache_add_dir(th_fcache* cache, th_string label, th_string path)
 {
     return th_dir_mgr_add(&cache->dir_mgr, label, path);
 }

--- a/src/th_fcache.h
+++ b/src/th_fcache.h
@@ -70,7 +70,7 @@ TH_PRIVATE(th_err)
 th_fcache_get(th_fcache* cache, th_string root, th_string path, th_fcache_entry** out);
 
 TH_PRIVATE(th_err)
-th_fcache_add_root(th_fcache* cache, th_string label, th_string path);
+th_fcache_add_dir(th_fcache* cache, th_string label, th_string path);
 
 TH_PRIVATE(th_dir*)
 th_fcache_find_dir(th_fcache* cache, th_string label);

--- a/src/th_fcache_test.c
+++ b/src/th_fcache_test.c
@@ -25,7 +25,7 @@ TH_TEST_BEGIN(fcache)
         th_fcache_entry* entry1 = NULL;
         th_fcache_entry* entry2 = NULL;
         th_fcache_entry* entry3 = NULL;
-        TH_EXPECT(th_fcache_add_root(&cache, TH_STRING("/"), TH_STRING("/")) == TH_ERR_OK);
+        TH_EXPECT(th_fcache_add_dir(&cache, TH_STRING("/"), TH_STRING("/")) == TH_ERR_OK);
         TH_EXPECT(th_fcache_get(&cache, TH_STRING("/"), TH_STRING("test"), &entry1) == TH_ERR_OK);
         TH_EXPECT(th_fcache_get(&cache, TH_STRING("/"), TH_STRING("test"), &entry2) == TH_ERR_OK);
         TH_EXPECT(th_fcache_get(&cache, TH_STRING("/"), TH_STRING("test"), &entry3) == TH_ERR_OK);
@@ -41,7 +41,7 @@ TH_TEST_BEGIN(fcache)
     {
         th_fcache cache = {0};
         th_fcache_init(&cache, NULL);
-        TH_EXPECT(th_fcache_add_root(&cache, TH_STRING("/"), TH_STRING("/")) == TH_ERR_OK);
+        TH_EXPECT(th_fcache_add_dir(&cache, TH_STRING("/"), TH_STRING("/")) == TH_ERR_OK);
         th_mock_syscall_get()->open = th_mock_open_bad;
         th_fcache_entry* entry = NULL;
         TH_EXPECT(th_fcache_get(&cache, TH_STRING("/"), TH_STRING("test"), &entry) != TH_ERR_OK);

--- a/src/th_server.c
+++ b/src/th_server.c
@@ -192,9 +192,9 @@ th_server_route(th_server* server, th_method method, const char* path, th_handle
 }
 
 TH_LOCAL(th_err)
-th_server_add_root(th_server* server, const char* name, const char* path)
+th_server_add_dir(th_server* server, const char* name, const char* path)
 {
-    return th_fcache_add_root(&server->fcache, th_string_from_cstr(name), th_string_from_cstr(path));
+    return th_fcache_add_dir(&server->fcache, th_string_from_cstr(name), th_string_from_cstr(path));
 }
 
 TH_LOCAL(th_err)
@@ -242,9 +242,9 @@ th_route(th_server* server, th_method method, const char* route, th_handler hand
 }
 
 TH_PUBLIC(th_err)
-th_add_root(th_server* server, const char* name, const char* path)
+th_add_dir(th_server* server, const char* name, const char* path)
 {
-    return th_server_add_root(server, name, path);
+    return th_server_add_dir(server, name, path);
 }
 
 TH_PUBLIC(th_err)

--- a/th.c
+++ b/th.c
@@ -2641,7 +2641,7 @@ TH_PRIVATE(th_err)
 th_fcache_get(th_fcache* cache, th_string root, th_string path, th_fcache_entry** out);
 
 TH_PRIVATE(th_err)
-th_fcache_add_root(th_fcache* cache, th_string label, th_string path);
+th_fcache_add_dir(th_fcache* cache, th_string label, th_string path);
 
 TH_PRIVATE(th_dir*)
 th_fcache_find_dir(th_fcache* cache, th_string label);
@@ -3851,9 +3851,9 @@ th_server_route(th_server* server, th_method method, const char* path, th_handle
 }
 
 TH_LOCAL(th_err)
-th_server_add_root(th_server* server, const char* name, const char* path)
+th_server_add_dir(th_server* server, const char* name, const char* path)
 {
-    return th_fcache_add_root(&server->fcache, th_string_from_cstr(name), th_string_from_cstr(path));
+    return th_fcache_add_dir(&server->fcache, th_string_from_cstr(name), th_string_from_cstr(path));
 }
 
 TH_LOCAL(th_err)
@@ -3901,9 +3901,9 @@ th_route(th_server* server, th_method method, const char* route, th_handler hand
 }
 
 TH_PUBLIC(th_err)
-th_add_root(th_server* server, const char* name, const char* path)
+th_add_dir(th_server* server, const char* name, const char* path)
 {
-    return th_server_add_root(server, name, path);
+    return th_server_add_dir(server, name, path);
 }
 
 TH_PUBLIC(th_err)
@@ -9071,7 +9071,7 @@ th_fcache_try_get(th_fcache* cache, th_string root, th_string path)
 }
 
 TH_PRIVATE(th_err)
-th_fcache_add_root(th_fcache* cache, th_string label, th_string path)
+th_fcache_add_dir(th_fcache* cache, th_string label, th_string path)
 {
     return th_dir_mgr_add(&cache->dir_mgr, label, path);
 }

--- a/th.h
+++ b/th.h
@@ -329,12 +329,12 @@ th_err th_bind(th_server* server, const char* addr, const char* port, th_bind_op
 th_err th_route(th_server* server, th_method method, const char* route, th_handler handler, void* userp);
 
 /** th_err
- * @brief Add a root directory to the server.
- * @param name Label for the root directory.
+ * @brief Add a directory to the server (for serving or storing files).
+ * @param name Label for the directory.
  * @param path File system path.
  * @return TH_ERR_OK on success, otherwise an error code.
  */
-th_err th_add_root(th_server* server, const char* name, const char* path);
+th_err th_add_dir(th_server* server, const char* name, const char* path);
 
 /** th_poll
  * @brief Poll the server for any events and pending tasks.


### PR DESCRIPTION
- Renamed `add_root` functions to `add_dir` to bettter reflect their purpose.
- `add_dir` indicates that the added directories can be used in various contexts, not just for the root directory.