### PR TITLE
Fix: ensure reloading of overwritten files

### DIFF
--- a/src/th_file.c
+++ b/src/th_file.c
@@ -280,6 +280,7 @@ th_file_stat_hash_posix(th_file* stream)
     hash = FSTAT_HASH_NEXT(hash, (uint32_t)st.st_ino);
     hash = FSTAT_HASH_NEXT(hash, (uint32_t)st.st_uid);
     hash = FSTAT_HASH_NEXT(hash, (uint32_t)st.st_gid);
+    hash = FSTAT_HASH_NEXT(hash, (uint32_t)(st.st_nlink != 0));
     return hash;
 }
 #elif defined(TH_CONFIG_OS_WIN)


### PR DESCRIPTION
- Include `st_link` in the file_stat hash to ensure that files are reloaded after being deleted and recreated.